### PR TITLE
fix(hubert): Make dialogs on iOS take no more space than available on screen

### DIFF
--- a/packages/hubert/src/dialog/dialog.module.scss
+++ b/packages/hubert/src/dialog/dialog.module.scss
@@ -27,7 +27,7 @@
     @media screen and (max-width: $max-xs) {
       width: 100vw;
       height: 100vh;
-      max-height: 100vh;
+      height: -webkit-fill-available;
       border-radius: 0;
       margin: auto;
     }
@@ -67,6 +67,7 @@
       flex-grow: 0;
       justify-content: flex-end;
       padding-top: var(--lotta-spacing);
+
       button:not(:first-child) {
         margin-left: var(--lotta-spacing);
       }


### PR DESCRIPTION
Fixes #127